### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,9 +1,7 @@
 package com.scalesec.vulnado;
 
 import org.springframework.web.bind.annotation.*;
-import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
 
 


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 35f9619d074c09bb9f51c71ec4ee3105fd80b9b4

**Description:** The pull request modifies the `LinksController.java` file by removing unused imports. Specifically, the `org.springframework.boot.autoconfigure.*` and `java.io.Serializable` imports have been deleted. This change likely aims to clean up the code and improve readability by removing unnecessary dependencies.

**Summary:** 
- **File Modified:** `src/main/java/com/scalesec/vulnado/LinksController.java`
- **Changes Made:** 
  - Removed the import statement for `org.springframework.boot.autoconfigure.*`.
  - Removed the import statement for `java.io.Serializable`.

**Recommendation:** 
1. **Code Quality:** Removing unused imports is a good practice as it reduces clutter and potential confusion for developers. However, ensure that these imports are indeed unused throughout the file. If they are required in other parts of the code, their removal could lead to compilation errors.
2. **Testing:** After removing these imports, run the application and ensure that all functionalities of the `LinksController` class work as expected. This will confirm that the removed imports were truly unnecessary.
3. **Documentation:** If this change is part of a larger refactoring effort, document the rationale behind removing these imports for future reference.

**Explanation of vulnerabilities:** 
- **Potential Issue:** Removing imports does not introduce any direct vulnerabilities. However, if these imports were removed without verifying their usage, it could lead to runtime errors or broken functionality, which might indirectly expose vulnerabilities in the application.
- **Correction Suggestion:** Ensure that a static code analysis tool or IDE warnings were used to confirm that these imports were unused. If any of these imports are required in the future, reintroduce them with proper justification.

